### PR TITLE
Accommodate upstream changes to KVCache

### DIFF
--- a/src/examples/requirements.txt
+++ b/src/examples/requirements.txt
@@ -1,5 +1,5 @@
-mlx >= 0.13.0
-mlx-lm >= 0.13.0
+mlx >= 0.16.0
+mlx-lm >= 0.16.0
 sentencepiece
 fastapi
 pydantic

--- a/src/examples/reusable_kv_cache.py
+++ b/src/examples/reusable_kv_cache.py
@@ -56,7 +56,7 @@ class ReusableKVCache(KVCache):
             new_k = mx.zeros(k_shape, keys.dtype)
             new_v = mx.zeros(v_shape, values.dtype)
             if self.keys is not None:
-                if prev % self.step != 0:  # Resize when we hit a step
+                if prev % self.step != 0:
                     self.keys = self.keys[..., :prev, :]
                     self.values = self.values[..., :prev, :]
                 self.keys = mx.concatenate([self.keys, new_k], axis=2)

--- a/src/examples/reusable_kv_cache.py
+++ b/src/examples/reusable_kv_cache.py
@@ -56,7 +56,7 @@ class ReusableKVCache(KVCache):
             new_k = mx.zeros(k_shape, keys.dtype)
             new_v = mx.zeros(v_shape, values.dtype)
             if self.keys is not None:
-                if (prev + keys.shape[2]) > self.keys.shape[2]:
+                if prev % self.step != 0:  # Resize when we hit a step
                     self.keys = self.keys[..., :prev, :]
                     self.values = self.values[..., :prev, :]
                 self.keys = mx.concatenate([self.keys, new_k], axis=2)


### PR DESCRIPTION
Hi, I created another open-source project based on this one, Toolio (in which I credit upstream, of course). It has some code refactored from here, and I ran into an issue with `ReusableKVCache` based on recent modifications in [mlx-examples](https://github.com/ml-explore/mlx-examples/):

* https://github.com/ml-explore/mlx-examples/commit/69181e00584976f717c27f90c7e009e70cc1b0bf
* https://github.com/ml-explore/mlx-examples/commit/561dcf5643ecced3be9bf053499e0e2ea51e8686

i'm still grokking all this, so the PR might need a tweak, but I didn't want to sit on it when there could be discussion.

Thanks for llm-structured-output! Awesome project!